### PR TITLE
feat: add 2 fields for bio (en and pt) and make bio_en mandatory

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
 
       redirect_to mentors_path
     else
-      render :new, status: :bad_request
+      render :new, status: :bad_request # Maybe change this to Unauthorized instead?
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,8 @@ class User < ApplicationRecord
   end
 
   def self.search_word(word)
-    %w[users.name bio location url_text year_in year_out tags.name->>'pt' tags.name->>'en'].map do |field|
+    puts word
+    %w[users.name bio_en bio_pt location url_text year_in year_out tags.name->>'pt' tags.name->>'en'].map do |field|
       where(["unaccent(#{field}::text) ILIKE CONCAT('%', unaccent(?), '%')", word])
     end.reduce(&:or).joins(:tags).distinct
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,6 @@ class User < ApplicationRecord
   end
 
   def self.search_word(word)
-    puts word
     %w[users.name bio_en bio_pt location url_text year_in year_out tags.name->>'pt' tags.name->>'en'].map do |field|
       where(["unaccent(#{field}::text) ILIKE CONCAT('%', unaccent(?), '%')", word])
     end.reduce(&:or).joins(:tags).distinct

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -12,7 +12,8 @@ UserPolicy = Struct.new(:current_user, :record) do
   def permitted_attributes_for_update
     [
       :active,
-      :bio,
+      :bio_en,
+      :bio_pt,
       :email,
       :location,
       :name,

--- a/app/views/mentors/_mentor.html.erb
+++ b/app/views/mentors/_mentor.html.erb
@@ -45,11 +45,8 @@
     </div>
 
     <div class="biography">
-      <% if lang.to_s == "en" %>
-        <%= simple_format mentor.bio_en %>
-      <% else %>
-        <%= simple_format mentor.bio_pt %>
-      <% end %>
+      <% bio_text = (lang.to_s == "en" || mentor.bio_pt.blank?) ? mentor.bio_en : mentor.bio_pt %>
+      <%= simple_format bio_text %>
     </div>
   </section>
 <% end %>

--- a/app/views/mentors/_mentor.html.erb
+++ b/app/views/mentors/_mentor.html.erb
@@ -45,7 +45,11 @@
     </div>
 
     <div class="biography">
-      <%= simple_format mentor.bio %>
+      <% if lang.to_s == "en" %>
+        <%= simple_format mentor.bio_en %>
+      <% else %>
+        <%= simple_format mentor.bio_pt %>
+      <% end %>
     </div>
   </section>
 <% end %>

--- a/app/views/mentors/index.html.erb
+++ b/app/views/mentors/index.html.erb
@@ -6,5 +6,5 @@
 </div>
 
 <div class="mentor-list">
-  <%= render partial: 'mentor', collection: @mentors, cached: true %>
+  <%= render partial: 'mentor', collection: @mentors, cached: true, locals: { lang: @settings.locale } %>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -45,15 +45,24 @@
     <div class="label"><%= f.label :bio %></div>
     <div class="description"><%= t('helpers.description.user.bio') %></div>
     <div>
+      <p><b><%= t('helpers.description.user.guidelines.form') %></b></p>
       <ul>
         <li><%= t('helpers.description.user.guidelines.clear_sentences') %></li>
         <li><%= t('helpers.description.user.guidelines.no_acronyms') %></li>
         <li><%= t('helpers.description.user.guidelines.be_specific') %></li>
         <li><%= t('helpers.description.user.guidelines.text_length') %></li>
       </ul>
+      <p><b><%= t('helpers.description.user.guidelines.content') %></b></p>
+      <ul>
+        <li><%= t('helpers.description.user.guidelines.introduce') %></li>
+        <li><%= t('helpers.description.user.guidelines.background') %></li>
+        <li><%= t('helpers.description.user.guidelines.expertise') %></li>
+        <li><%= t('helpers.description.user.guidelines.explain') %></li>
+      </ul>
     </div>
     <div class="input"><%= f.text_area :bio_en, placeholder: 'English version (mandatory)', required: true %></div>
   </div>
+  <%= current_user.bio_pt %>
 
   <div class="field">
     <div class="input"><%= f.text_area :bio_pt, placeholder: 'Versão portuguesa' %></div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -44,6 +44,14 @@
   <div class="field">
     <div class="label"><%= f.label :bio %></div>
     <div class="description"><%= t('helpers.description.user.bio') %></div>
+    <div>
+      <ul>
+        <li><%= t('helpers.description.user.guidelines.clear_sentences') %></li>
+        <li><%= t('helpers.description.user.guidelines.no_acronyms') %></li>
+        <li><%= t('helpers.description.user.guidelines.be_specific') %></li>
+        <li><%= t('helpers.description.user.guidelines.text_length') %></li>
+      </ul>
+    </div>
     <div class="input"><%= f.text_area :bio_en, placeholder: 'English version (mandatory)', required: true %></div>
   </div>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -44,7 +44,11 @@
   <div class="field">
     <div class="label"><%= f.label :bio %></div>
     <div class="description"><%= t('helpers.description.user.bio') %></div>
-    <div class="input"><%= f.text_area :bio %></div>
+    <div class="input"><%= f.text_area :bio_en, placeholder: 'English version (mandatory)', required: true %></div>
+  </div>
+
+  <div class="field">
+    <div class="input"><%= f.text_area :bio_pt, placeholder: 'Versão portuguesa' %></div>
   </div>
 
   <div class="field">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
     description:
       user:
         active: We only list active members on the platform. Mark yourself as inactive if you don't want to be contacted by students.
-        bio: Your biography. Focus career decisions that you might have had questions about when you were a student.
+        bio: 'Your biography. Focus on career decisions that you might have had questions about when you were a student. Below are some guidelines:'
         tags: Tags that describe the experiences that you have gone through. Select all that apply or have applied in the past.
         location: 'Your current location, in "city, country" format. Example: Porto, Portugal.'
         name: Your preferred name.
@@ -22,6 +22,11 @@ en:
         url_text: Links to your personal website or social profiles. One URL per line.
         year_in: The first year you enrolled in LEIC/MIEIC.
         year_out: The last year you were enrolled in LEIC/MIEIC.
+        guidelines:
+          clear_sentences: Write clear simple sentences;
+          no_acronyms: Avoid using acronyms;
+          be_specific: Be specific when sharing information;
+          text_length: Too much and too little text is what we want to avoid, aim for 4 to 5 paragraphs;
       settings:
         theme: Changes the theme of the website to either the 'dark', 'light' or 'system' themes
         locale: Changes the language of the website

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,10 +23,16 @@ en:
         year_in: The first year you enrolled in LEIC/MIEIC.
         year_out: The last year you were enrolled in LEIC/MIEIC.
         guidelines:
+          form: Form
+          content: Content
           clear_sentences: Write clear simple sentences;
           no_acronyms: Avoid using acronyms;
           be_specific: Be specific when sharing information;
           text_length: Too much and too little text is what we want to avoid, aim for 4 to 5 paragraphs;
+          introduce: Introduce yourself;
+          background: Summarise your background;
+          expertise: Highlight your areas of expertise acquired by your life experiences or career;
+          explain: Explain why you joined Mentorados;
       settings:
         theme: Changes the theme of the website to either the 'dark', 'light' or 'system' themes
         locale: Changes the language of the website

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,7 +13,7 @@ pt:
     description:
       user:
         active: Só os membros activos são listados na plataforma. Marca-te como inactivo se não quiseres ser contactado por estudantes.
-        bio: A tua biografia. Foca-te nas decisões de carreira sobre as quais poderias ter tido questões quando eras estudante.
+        bio: 'A tua biografia. Foca-te nas decisões de carreira sobre as quais poderias ter tido questões quando eras estudante. Abaixo estão algumas dicas:'
         tags: Etiquetas que se apliquem às experiências que viveste. Selecciona todas as que são ou já foram relevantes.
         location: 'A tua localização actual, no formato "cidade, país". Exemplo: Porto, Portugal.'
         name: O teu nome preferencial.
@@ -22,6 +22,11 @@ pt:
         url_text: Endereço da tua página pessoal ou das tuas redes sociais. Um endereço por linha.
         year_in: O primeiro ano em que estiveste inscrito no curso LEIC/MIEIC.
         year_out: O último ano em que estiveste inscrito no curso LEIC/MIEIC.
+        guidelines:
+          clear_sentences: Escreve frases simples e claras;
+          no_acronyms: Evita usar acrónimos;
+          be_specific: Sê específico quando partilhares informação;
+          text_length: Demasiado ou muito pouco texto é que queremos evitar, aponta para 4 ou 5 parágrafos;
       settings:
         theme: Altera o tema da página entre as opções 'light', 'dark' e 'system'
         locale: Altera a língua da página

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,7 +13,7 @@ pt:
     description:
       user:
         active: Só os membros activos são listados na plataforma. Marca-te como inactivo se não quiseres ser contactado por estudantes.
-        bio: 'A tua biografia. Foca-te nas decisões de carreira sobre as quais poderias ter tido questões quando eras estudante. Abaixo estão algumas dicas:'
+        bio: 'A tua biografia. Foca-te nas decisões de carreira sobre as quais poderias ter tido questões quando eras estudante. Abaixo estão algumas indicações:'
         tags: Etiquetas que se apliquem às experiências que viveste. Selecciona todas as que são ou já foram relevantes.
         location: 'A tua localização actual, no formato "cidade, país". Exemplo: Porto, Portugal.'
         name: O teu nome preferencial.
@@ -23,10 +23,16 @@ pt:
         year_in: O primeiro ano em que estiveste inscrito no curso LEIC/MIEIC.
         year_out: O último ano em que estiveste inscrito no curso LEIC/MIEIC.
         guidelines:
+          form: Forma
+          content: Conteúdo
           clear_sentences: Escreve frases simples e claras;
           no_acronyms: Evita usar acrónimos;
           be_specific: Sê específico quando partilhares informação;
           text_length: Demasiado ou muito pouco texto é que queremos evitar, aponta para 4 ou 5 parágrafos;
+          introduce: Apresenta-te;
+          background: Resume o teu background;
+          expertise: Destaca as tuas áreas de experiência, obtidas nas tuas experiências de vida ou carreira;
+          explain: Explica o porquê de te teres juntado aos Mentorados;
       settings:
         theme: Altera o tema da página entre as opções 'light', 'dark' e 'system'
         locale: Altera a língua da página

--- a/db/migrate/20210703123850_add_bios_in_two_languages.rb
+++ b/db/migrate/20210703123850_add_bios_in_two_languages.rb
@@ -1,0 +1,6 @@
+class AddBiosInTwoLanguages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :bio_en, :text
+    rename_column :users, :bio, :bio_pt
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_034046) do
+ActiveRecord::Schema.define(version: 2021_07_03_123850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_034046) do
     t.boolean "mentor", default: false, null: false
     t.boolean "active", default: false
     t.text "name"
-    t.text "bio"
+    t.text "bio_pt"
     t.integer "year_in"
     t.integer "year_out"
     t.text "location"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_034046) do
     t.uuid "invitation_id"
     t.uuid "invited_by_id"
     t.datetime "invited_at"
+    t.text "bio_en"
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
   end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15149259/124359281-8d26dd80-dc24-11eb-8aac-7a648e2139d8.png)

- Added a field for the PT bio.
- Made EN bio mandatory.
- Added placeholders in each bio field (informing which language it is)
- Show the mentor bio in the correct language (according to the user settings)
- Show EN bio if no PT bio is found.